### PR TITLE
Added default value for PullCommand to mirror FetchCommand

### DIFF
--- a/src/Command/PullCommandBuilder.php
+++ b/src/Command/PullCommandBuilder.php
@@ -74,7 +74,6 @@ class PullCommandBuilder implements CommandBuilderInterface
         return $this;
     }
 
-
     /**
      * Build the command and execute it.
      *
@@ -90,7 +89,7 @@ class PullCommandBuilder implements CommandBuilderInterface
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      * @SuppressWarnings(PHPMD.CamelCaseParameterName)
      */
-    public function execute($repository, $refspec = null, $_ = null)
+    public function execute($repository = 'origin', $refspec = null, $_ = null)
     {
         $this->arguments[] = $repository;
 


### PR DESCRIPTION
Due to the lack of documentation for the pull command, I turned to the source code to identify why the command was not working with a plain execute() call as the fetch command does, found out there is no default value for the $repository variable.

I added updated the PullCommand execute params so that $repository = 'origin' to decrease further problems with said command.